### PR TITLE
Fix fish build command for the source tarball

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -480,7 +480,7 @@ title: fish shell
 
         <p>
           <small>
-            <span class="mono">./configure; make; sudo make install</span>
+            <span class="mono">cmake .; make; sudo make install</span>
           </small>
         </p>
 


### PR DESCRIPTION
The command to build the source from a tarball says to run a `./configure` command that appears to have been removed when CMake was added.